### PR TITLE
[수정] Update Page 예외처리 (closed #24) / ListContainer 내부 Post 컴포넌트 스타일 변경 (fixed #16)

### DIFF
--- a/src/components/Post/Post.styled.tsx
+++ b/src/components/Post/Post.styled.tsx
@@ -12,8 +12,7 @@ const StyledPost = styled(Post)`
   height: 200px;
   font-size: 1.4rem;
   border-top: 1px solid #ccc;
-  border-bottom: 1px solid #ccc;
-  margin: 10px 0;
+  margin-top: 10px 0;
   /* box-shadow: 0 10px 10px 3px rgba(110, 109, 110, 0.24); */
 
   & > * {

--- a/src/containers/Editor/TextEditor.styled.tsx
+++ b/src/containers/Editor/TextEditor.styled.tsx
@@ -18,17 +18,6 @@ const StyledTextEditor = styled(TextEditor)`
   .editor::-webkit-scrollbar {
     display: none;
   }
-
-  .btn-group {
-    position: fixed;
-    bottom: 15px;
-
-    & > button {
-      border-radius: 15px;
-      border: 1px solid #ccc;
-      margin: 0 10px;
-    }
-  }
 `;
 
 export default StyledTextEditor;

--- a/src/containers/Editor/TextEditor.tsx
+++ b/src/containers/Editor/TextEditor.tsx
@@ -30,8 +30,6 @@ const TextEditor = ({ className, defaultContent }: TextEditorProps) => {
   /* Draft.js-------------------------------------------------------------------------- */
 
   useEffect(() => {
-    console.log(defaultContent);
-
     if (defaultContent) {
       if (rendered.current) return;
       rendered.current = true;

--- a/src/containers/Editor/TextEditor.tsx
+++ b/src/containers/Editor/TextEditor.tsx
@@ -30,6 +30,8 @@ const TextEditor = ({ className, defaultContent }: TextEditorProps) => {
   /* Draft.js-------------------------------------------------------------------------- */
 
   useEffect(() => {
+    console.log(defaultContent);
+
     if (defaultContent) {
       if (rendered.current) return;
       rendered.current = true;

--- a/src/containers/ModalDialogs/AlertCancelWriter.tsx
+++ b/src/containers/ModalDialogs/AlertCancelWriter.tsx
@@ -2,7 +2,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { MouseEventHandler } from "react";
 import { useHistory } from "react-router";
 import { combinedState } from "constant/type";
-import { resetState } from "redux/reducers/newPost";
+import { resetStateAction } from "redux/reducers/newPost";
 import { createCloseAllAction } from "redux/reducers/openModal";
 import Title from "components/Title/Title";
 import Button from "components/Button/Button";
@@ -18,7 +18,7 @@ const AlertCancelWriter = () => {
   );
 
   const CancelWriter: MouseEventHandler = () => {
-    dispatch(resetState());
+    dispatch(resetStateAction());
     dispatch(createCloseAllAction());
     history.replace("/");
   };

--- a/src/containers/WriteHeader/WriteHeader.tsx
+++ b/src/containers/WriteHeader/WriteHeader.tsx
@@ -10,7 +10,7 @@ import { post } from "../../constant/type";
 import {
   titleAction,
   subTitleAction,
-  resetBackground,
+  resetBackgroundAction,
 } from "../../redux/reducers/newPost";
 import invertColor from "modules/calOppositeColor";
 import CancelIcon from "essets/Icons/CancelIcon";
@@ -26,7 +26,7 @@ const WriteHeader = ({ className, Post }: writeHeaderProps) => {
   const oppositeColor = invertColor(Post.backgroundColor);
 
   const onClickResetButton = () => {
-    dispatch(resetBackground());
+    dispatch(resetBackgroundAction());
   };
 
   const onChangeTitle = ({ target }: { target: HTMLInputElement }) => {

--- a/src/pages/UpdatePage.tsx
+++ b/src/pages/UpdatePage.tsx
@@ -8,7 +8,7 @@ import StyledButton from "components/Button/Button.styled";
 import { createOpenAction } from "redux/reducers/openModal";
 import { useRouteMatch, useHistory } from "react-router";
 import { useEffect } from "react";
-import { postAction, resetState } from "redux/reducers/newPost";
+import { postAction, resetStateAction } from "redux/reducers/newPost";
 
 type UpdatePageProps = {
   className?: string;
@@ -26,12 +26,15 @@ const UpdatePage = ({ className }: UpdatePageProps) => {
     const getPostAsync = async () => {
       const post = (await getPost(postId)) as post;
       if (post) {
-        console.log(post);
         dispatch(postAction(post));
       }
     };
 
     getPostAsync();
+
+    return () => {
+      dispatch(resetStateAction());
+    };
   }, []);
 
   const onClickSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -39,7 +42,7 @@ const UpdatePage = ({ className }: UpdatePageProps) => {
       dispatch(createOpenAction("isOpenAlertWritePost"));
     } else {
       await addPost(newPost);
-      dispatch(resetState());
+      dispatch(resetStateAction());
       history.replace(`/${postId}`);
     }
   };

--- a/src/pages/WritePage.tsx
+++ b/src/pages/WritePage.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { combinedState } from "constant/type";
-import { idAction, dateAction, resetState } from "redux/reducers/newPost";
+import { idAction, dateAction, resetStateAction } from "redux/reducers/newPost";
 import { addPost } from "fb/API";
 import styled from "styled-components";
 import StyledWriteHeader from "containers/WriteHeader/WriteHeader.styled";
@@ -29,7 +29,7 @@ const WritePage = ({ className }: writePageProps) => {
     } else {
       dispatch(dateAction(new Date()));
       await addPost(newPost);
-      dispatch(resetState());
+      dispatch(resetStateAction());
       history.replace(`/${newPost.id}`);
     }
   };

--- a/src/redux/reducers/newPost.ts
+++ b/src/redux/reducers/newPost.ts
@@ -85,11 +85,11 @@ export const backgroundImageAction = (backgroundImage: unknown) => ({
   payload: backgroundImage,
 });
 
-export const resetBackground = () => ({
+export const resetBackgroundAction = () => ({
   type: RESET_BACKGROUND,
 });
 
-export const resetState = () => ({
+export const resetStateAction = () => ({
   type: RESET_STATE,
 });
 


### PR DESCRIPTION
1. UpdatePage Unmount될 때 newPost 리덕스 상태를 초기화함으로써 전에
   있던 기존 newPost 데이터가 새로운 업데이트 창에 덮어씌어지는 경우를
   방지한다.

2. newPost 관련 dipatch 함수 이름 변경