### PR TITLE
[추가] Post 컴포넌트 Like, Comment 개수 랜더  기능 추가 (solved #42)

### DIFF
--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -9,7 +9,7 @@ type postProps = {
   subTitle?: string;
   summary?: string;
   date?: string;
-  likeCount?: number;
+  likeCount: number;
   commentCount?: number;
 };
 //TODO: access에 따른 render 여부 접근 여부 설정, like, comment 수로 개별 render

--- a/src/constant/type.ts
+++ b/src/constant/type.ts
@@ -11,6 +11,8 @@ type post = {
   category: string;
   backgroundImage: string;
   backgroundColor: string;
+  likeUser: string[];
+  commentUser: string[];
 };
 
 type postsList = post[];
@@ -31,7 +33,7 @@ type salonInfo = {
 
 type postFromFirestore = {
   access: string;
-  id: number;
+  id: string;
   title: string;
   subTitle: string;
   date: firebase.firestore.Timestamp;
@@ -39,6 +41,8 @@ type postFromFirestore = {
   category: string;
   backgroundImage: string;
   backgroundColor: string;
+  likeUser: string[];
+  commentUser: string[];
 };
 
 type combinedState = CombinedState<{

--- a/src/containers/Comment/Comment.tsx
+++ b/src/containers/Comment/Comment.tsx
@@ -4,11 +4,20 @@ import { combinedState } from "constant/type";
 import StyledCommentList from "containers/CommentList/CommentList.styled";
 import useAuthStateObserver from "customHook/useAuthStateObserver";
 import { addComment } from "fb/API";
-import { ChangeEventHandler, MouseEventHandler, useEffect, useState } from "react";
+import {
+  ChangeEventHandler,
+  MouseEventHandler,
+  useEffect,
+  useState,
+} from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useRouteMatch } from "react-router";
-import { $CombinedState } from "redux";
-import { commentAction, idAction, postIdAction, userAction } from "redux/reducers/newComment";
+import {
+  commentAction,
+  idAction,
+  postIdAction,
+  userAction,
+} from "redux/reducers/newComment";
 
 const placeHolder =
   "좋은 글을 남겨 주신 작가님께 편지를 남겨 보세요. 편지는 작가님과 작성자에게만 공개됩니다.";
@@ -24,7 +33,7 @@ const Comment = () => {
   const dispatch = useDispatch();
 
   const onChangeComment: ChangeEventHandler<HTMLTextAreaElement> = ({
-    target
+    target,
   }: {
     target: HTMLTextAreaElement;
   }) => {
@@ -34,7 +43,7 @@ const Comment = () => {
 
   const newComment = useSelector((state: combinedState) => state.newComment);
 
-  const onClick: MouseEventHandler = target => {
+  const onClick: MouseEventHandler = (target) => {
     // dispatch(idAction("4"));
     addComment(newComment);
   };
@@ -64,7 +73,9 @@ const Comment = () => {
         </StyledTextArea>
       </div>
       <div>
-        <StyledCommentButton onClick={onClick}>Letter to writer</StyledCommentButton>
+        <StyledCommentButton onClick={onClick}>
+          Letter to writer
+        </StyledCommentButton>
       </div>
     </>
   );

--- a/src/containers/LikeList/LikeList.tsx
+++ b/src/containers/LikeList/LikeList.tsx
@@ -55,8 +55,10 @@ const LikeList = ({ className }: likeList) => {
             subTitle={post.subTitle}
             summary={post.content}
             date={`${convertToDate(post.date)}`}
-            likeCount={0}
-            commentCount={0}
+            likeCount={post.likeUser ? post.likeUser.length : [].length}
+            commentCount={
+              post.commentUser ? post.commentUser.length : [].length
+            }
           />
         </Link>
       ))}

--- a/src/containers/ListContainer/ListContainer.tsx
+++ b/src/containers/ListContainer/ListContainer.tsx
@@ -44,8 +44,10 @@ const ListContainer = ({ className }: listContainerProps) => {
             subTitle={post.subTitle}
             summary={post.content}
             date={`${convertToDate(post.date)}`}
-            likeCount={0}
-            commentCount={0}
+            likeCount={post.likeUser ? post.likeUser.length : [].length}
+            commentCount={
+              post.commentUser ? post.commentUser.length : [].length
+            }
           />
         </Link>
       ))}

--- a/src/redux/reducers/newPost.ts
+++ b/src/redux/reducers/newPost.ts
@@ -25,6 +25,8 @@ const initialState: post = {
   category: "All",
   backgroundImage: "",
   backgroundColor: "#fff",
+  likeUser: [],
+  commentUser: [],
 };
 
 export const idAction = () => async (


### PR DESCRIPTION
1. post type 재정의
2. 좋아요 댓글 배열을 firestore에서 받아 length를 활용해 개수를 구함.
3. 이전에 생성한 게시물의 경우 like, comment count 프로퍼티가 없기 때문에
배열이 undefined일 경우를 빈배열을 기본값으로 설정